### PR TITLE
Push changes from the open file to the block editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,21 @@
 
 All notable changes to the "playground-readme-editor" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
+## 1.0.0
 
 - Initial release
+
+## 1.0.1
+
+- Updates to ReadMe.
+- Fix empty files being update with placeholder text.
+
+## 1.1.0
+
+- Add Open block editor button
+- Add GPL license
+- Add temporary WordPress icon
+
+## 1.1.1
+
+- Only focus the window when it is editable.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument(
+      (e: vscode.TextDocumentChangeEvent) => {
+        provider.refreshPlayground(e?.document);
+      }
+    )
+  );
 }
 
 // This method is called when your extension is deactivated

--- a/src/playgroundWebViewProvider.ts
+++ b/src/playgroundWebViewProvider.ts
@@ -10,6 +10,7 @@ export default class PlaygroundWebViewProvider
   private _view?: vscode.WebviewView;
   private _activeDoc?: vscode.TextDocument;
   private _canEdit: boolean = false;
+  private _currentText: string = '';
 
   constructor(private readonly _extensionUri: vscode.Uri) {}
 
@@ -30,7 +31,8 @@ export default class PlaygroundWebViewProvider
       this._activeDoc = evt;
       this._canEdit = this._allowedLangs.includes(this._activeDoc.languageId);
       const docText = this._activeDoc.getText().trim();
-      if (this._view) {
+
+      if (this._view && this._currentText !== docText) {
         this._view.webview.postMessage({
           command: 'setEditorContent',
           format: 'markdown',
@@ -40,6 +42,7 @@ export default class PlaygroundWebViewProvider
               : '## Insert blocks to get started'
             : `## ${this._activeDoc.languageId} files are not supported`,
         });
+        this._currentText = docText;
       }
       // Set the activeEditor to which ever one was opened/changed
       if (this._canEdit) {


### PR DESCRIPTION
It looks like being able to paste directly into the block editor is going to be harder to implement than expected. See https://github.com/microsoft/vscode/issues/65452#issuecomment-586485815 for more context.

I have tried a few different approaches to pass the events and data to the block editor. All with mixed and unreliable results. I think this is the most straight forward way to allow pasting and also solves the issue of not having two way updating in place.

Closes #10 and #6 